### PR TITLE
Example j2

### DIFF
--- a/Systronix_PCA9557.cpp
+++ b/Systronix_PCA9557.cpp
@@ -57,7 +57,7 @@ Compiler has major whines if called as shown in the online Wire reference.
 #include <Arduino.h>
 #include "Systronix_PCA9557.h"
 
-#define _DEBUG 1
+#define _DEBUG 0
 
 /**************************************************************************/
 /*!
@@ -240,7 +240,7 @@ uint8_t Systronix_PCA9557::pin_pulse (uint8_t pin_mask, boolean idle_high)
 {
 	uint8_t b = 0;
 	
-	if (_DEBUG>0) Serial.print("pin_mask=0x"); Serial.println(pin_mask, HEX);
+//	if (_DEBUG>0) Serial.print("pin_mask=0x"); Serial.println(pin_mask, HEX);
 
 	if (idle_high)
 	{
@@ -251,7 +251,7 @@ uint8_t Systronix_PCA9557::pin_pulse (uint8_t pin_mask, boolean idle_high)
 		_out_data |= (pin_mask);	// set outputs to be pulsed	high	
 	}
 	// pulse outputs to non-idle state
-	if (_DEBUG>0) {Serial.print("pulse out_data=0x"); Serial.println(_out_data, HEX);}
+//	if (_DEBUG>0) {Serial.print("pulse out_data=0x"); Serial.println(_out_data, HEX);}
 	register_write(PCA9557_OUT_PORT_REG, _out_data);
 
 	if (idle_high)
@@ -263,19 +263,20 @@ uint8_t Systronix_PCA9557::pin_pulse (uint8_t pin_mask, boolean idle_high)
 		_out_data &= ((~pin_mask) & 0x0FF);	// clr outputs to be idled low		
 	}
 	// restore outputs to idle state
-	if (_DEBUG>0) {Serial.print("pulse out_data=0x"); Serial.println(_out_data, HEX);}
+//	if (_DEBUG>0) {Serial.print("pulse out_data=0x"); Serial.println(_out_data, HEX);}
 	register_write(PCA9557_OUT_PORT_REG, _out_data);
 	
 	return b;
 }
 
- /*
+ /**
  * Drive pin(s) to a high or low voltage level
  * If boolean high is true they will be driven to a high level.
  * Leave with pin(s) in new state.
  * Example: 
- * pin_drive (0xFF, true) will set ALL pins high
  * pin_drive (0x02, true) 0x02 will drive output 1 to high level.
+ * pin_drive (0xFF, true) will set pins IO7–IO1 high, IO0 will drive active low
+ * NOTE: IO0 output IS opposite to all other outputs
  *
  * This only actually drives pins defined as outputs in the config register
  * 
@@ -287,12 +288,12 @@ uint8_t Systronix_PCA9557::pin_pulse (uint8_t pin_mask, boolean idle_high)
  *
  * @param pin [0..0xFF] the device output pin(s) you want to drive to new state
  * @param high if true sets pin(s) high otherwise will drive to low level
- */
+ **/
 uint8_t Systronix_PCA9557::pin_drive (uint8_t pin_mask, boolean high)
 {
 	uint8_t b = 0;
 	
-	if (_DEBUG>0) Serial.print("drive pin_mask=0x"); Serial.println(pin_mask, HEX);
+//	if (_DEBUG>0) Serial.print("drive pin_mask=0x"); Serial.println(pin_mask, HEX);
 
 	if (high)
 	{
@@ -304,7 +305,7 @@ uint8_t Systronix_PCA9557::pin_drive (uint8_t pin_mask, boolean high)
 			
 	}
 	// drive output(s) to new state
-	if (_DEBUG>0) {Serial.print("drive out_data=0x"); Serial.println(_out_data, HEX);}
+//	if (_DEBUG>0) {Serial.print("drive out_data=0x"); Serial.println(_out_data, HEX);}
 	register_write(PCA9557_OUT_PORT_REG, _out_data);
 	
 	return b;

--- a/Systronix_PCA9557.cpp
+++ b/Systronix_PCA9557.cpp
@@ -69,8 +69,8 @@ Systronix_PCA9557::Systronix_PCA9557(uint8_t base)
 {
 	_base = base;
 	BaseAddr = base;
-	static data _data;		// instance of the data struct
-	_data.address = _base;	// struct
+//	static data _data;		// instance of the data struct
+//	_data.address = _base;	// struct
 	_inp_data = 0;
 	_out_data = 0;
 	_invert_mask = 0;
@@ -82,28 +82,26 @@ Systronix_PCA9557::Systronix_PCA9557(uint8_t base)
     @brief  Join the I2C bus as a master, call this once in setup()
 */
 /**************************************************************************/
-void Systronix_PCA9557::begin(void) {
-	// 
+void Systronix_PCA9557::begin(void)
+{
 	Wire.begin();	// join I2C as master
 	
 	// @TODO add default read first thing to see if it is the control reg
 	// but even if it is, is it any use? How would we know what to expect?
-
 }
 
 /**
  *  @brief Initialize the 9557 to a given state. Can be called as often as needed.
  *  
- *  Call after a hardware reset, if a reset can be caused programaatically.
+ *  Call after a hardware reset, if a reset can be caused programatically.
  *  @param outmask set bits will be outputs. 0xFF makes all pins outputs
  *  @param output value to write to output pins, writing a 1 drives outputs high
- *  except bit 0 which is open drain. 
+ *  except bit 0 which is open drain so drives low. 
  *  @param invertmask applies to pins set as inputs. Setting a mask bit inverts that
  *  input when it is read. After POR this reg is 0xF0
  */
-void Systronix_PCA9557::init(uint8_t outmask, uint8_t output, uint8_t invertmask) {
-	
-
+void Systronix_PCA9557::init(uint8_t outmask, uint8_t output, uint8_t invertmask)
+{
 	// remember current invert mask
 	_invert_mask = invertmask;
 	// remember our current data output
@@ -155,14 +153,14 @@ void Systronix_PCA9557::init(uint8_t outmask, uint8_t output, uint8_t invertmask
 uint8_t Systronix_PCA9557::control_write (uint8_t data)
 {
 	uint8_t b = 0;
-	  Wire.beginTransmission(_base);
+	 Wire.beginTransmission(_base);
 
-	  // returns # of bytes written
-	  b = Wire.write(data);
-	  // returns 0 if no error
-	  b+= Wire.endTransmission();
+	 // returns # of bytes written
+	 b = Wire.write(data);
+	 // returns 0 if no error
+	 b+= Wire.endTransmission();
 
-	 return b;
+	return b;
 }
 
 /**
@@ -240,7 +238,9 @@ uint8_t Systronix_PCA9557::pin_pulse (uint8_t pin_mask, boolean idle_high)
 {
 	uint8_t b = 0;
 	
-//	if (_DEBUG>0) Serial.print("pin_mask=0x"); Serial.println(pin_mask, HEX);
+#if 0 < _DEBUG
+	Serial.print("pin_mask=0x"); Serial.println(pin_mask, HEX);
+#endif
 
 	if (idle_high)
 	{
@@ -250,8 +250,10 @@ uint8_t Systronix_PCA9557::pin_pulse (uint8_t pin_mask, boolean idle_high)
 	{
 		_out_data |= (pin_mask);	// set outputs to be pulsed	high	
 	}
+#if 0 < _DEBUG
+	Serial.print("pulse out_data=0x"); Serial.println(_out_data, HEX);
+#endif
 	// pulse outputs to non-idle state
-//	if (_DEBUG>0) {Serial.print("pulse out_data=0x"); Serial.println(_out_data, HEX);}
 	register_write(PCA9557_OUT_PORT_REG, _out_data);
 
 	if (idle_high)
@@ -262,8 +264,10 @@ uint8_t Systronix_PCA9557::pin_pulse (uint8_t pin_mask, boolean idle_high)
 	{
 		_out_data &= ((~pin_mask) & 0x0FF);	// clr outputs to be idled low		
 	}
+#if 0 < _DEBUG
+	Serial.print("pulse out_data=0x"); Serial.println(_out_data, HEX);
+#endif
 	// restore outputs to idle state
-//	if (_DEBUG>0) {Serial.print("pulse out_data=0x"); Serial.println(_out_data, HEX);}
 	register_write(PCA9557_OUT_PORT_REG, _out_data);
 	
 	return b;
@@ -293,7 +297,9 @@ uint8_t Systronix_PCA9557::pin_drive (uint8_t pin_mask, boolean high)
 {
 	uint8_t b = 0;
 	
-//	if (_DEBUG>0) Serial.print("drive pin_mask=0x"); Serial.println(pin_mask, HEX);
+#if 0 < _DEBUG
+	Serial.print("drive pin_mask=0x"); Serial.println(pin_mask, HEX);
+#endif
 
 	if (high)
 	{
@@ -305,7 +311,9 @@ uint8_t Systronix_PCA9557::pin_drive (uint8_t pin_mask, boolean high)
 			
 	}
 	// drive output(s) to new state
-//	if (_DEBUG>0) {Serial.print("drive out_data=0x"); Serial.println(_out_data, HEX);}
+#if 0 < _DEBUG
+	Serial.print("drive out_data=0x"); Serial.println(_out_data, HEX);
+#endif
 	register_write(PCA9557_OUT_PORT_REG, _out_data);
 	
 	return b;

--- a/examples/PCA9557_J2/PCA9557_J2.ino
+++ b/examples/PCA9557_J2/PCA9557_J2.ino
@@ -21,41 +21,36 @@
  *  2016 May 26 bboyes moved into Systronix_PCA9557 examples folder
  *				Changed name to PCA9557_J2
  *  2016 May 15 bboyes Start with new SALT 2v0 board
+ *	2016 Jul 4	wsk		complete thrash of this example used as a test bed for SALT_JX class
  */
 
 
 #include <Arduino.h>
 #include <Systronix_PCA9557.h>
+#include <SALT_JX.h>
 #include <NAP_pod_load_defs.h>
-
- /**
- * debug level
- * 0 = quiet, suppress everything
- * 3 = max, even more or less trivial message are emitted
- * 4 = emit debug info which checks very basic data conversion, etc
- */
- byte DEBUG = 1;
-
-
-uint16_t dtime = 1000;  // delay in loop
 
 /**
  * These are the addresses of the I2C devices which drive the related
  * Core DB15 connector and the Core FETs
- * @TODO make these addresses manifest constants in some appropriate way
+ * @TODO make these addresses manifest constants in some appropriate way; put them in a common .h file somewhere if they are needed in more than one file
  */
 #define I2C_J2 0x1B
 #define I2C_J3 0x1A
 #define I2C_J4 0x19
 #define I2C_FET 0x1C
 
+// TODO: move to common .h file
+#define JX_LED_ON	false		// yes, opposite to the other bits.  writing a 1 to the 9557 output register
+#define JX_LED_OFF	true		// turns the output FET OFF
+
 
 /**
- *  These are signal names specific to our custom SALT2 hardware
+ *  These are signal names specific to our custom SALT2 hardware; TODO: move to common .h file
  */
 
 // SALT2 Core SDOUT on J2,3,4 pins 1/2 to '595 SDIN of DC and AC boards: 9557 IO7, 0x80 
-// output from 9577 to '595 Din
+// output from 9557 to '595 Din
 #define SDOUT BIT7 	// 0x80
 
 // SALT2 Core SCLK on J2,3,4 pins 5/6 to '595 and '165 SCLK of DC and AC boards: 9557 IO6, 0x40,
@@ -77,34 +72,57 @@ uint16_t dtime = 1000;  // delay in loop
 // bits 1 and 2 (0x02, 0x04) not connected
 
 // SALT2 yellow LED for J2,3,4 intended to show activity on that port: 9557 IO0, 0x01 
-// open drain, clearing this bit drives output low = LED on
+// open drain, SETTING (yes, opposite to the other bits) this bit drives output low = LED on
 #define LED BIT0	// 0x01
+
+// coreFET defines: TODO: move to appropriate .h file
+// LED on bit 0 uses the LED define above
+#define	LIGHTS		BIT2		// when set HIGH, turns on the habitats' fluorescent lights
+#define	ALARM		BIT3		// when set HIGH, sounds the alarm at the top of the A habitat
+#define	FAN3		BIT5		// when set HIGH, turns on the left-most fan
+#define	FAN2		BIT6		// when set HIGH, turns on the middle fan
+#define	FAN1		BIT7		// when set HIGH, turns on the right-most fan
+
 
 /**
  *  bit 5 is input; bits 2 and 1 are not connected, Bit 0 is the activity LED for that device
  *  so this mask has a '1' for every bit which is used as output
  *  Note: enclosing parentheses are required to force the '~' operator to operate on the whole quantity
- *  not just the first manifest constant!
+ *  not just the first manifest constant! TODO: move to common .h file
  */
 #define OUTMASK (RCLK595 | SCLK | SDOUT | SHIFT165 | LED)
 
 /**
- *  Only one actual input, serial data in
+ *  Only one actual input, serial data in; TODO: move to common .h file
  */
 #define INMASK (SDIN)
 
-Systronix_PCA9557 coreJ2(I2C_J2);
-Systronix_PCA9557 coreJ3(I2C_J3);
-Systronix_PCA9557 coreJ4(I2C_J4);
+SALT_JX coreJ2 (2);
+//SALT_JX coreJ3 (3);
+//SALT_JX coreJ4 (4);
+
+Systronix_PCA9557 coreJ2reg(I2C_J2);
+Systronix_PCA9557 coreJ3reg(I2C_J3);
+Systronix_PCA9557 coreJ4reg(I2C_J4);
 
 Systronix_PCA9557 coreFET(I2C_FET);
 
+// TODO: move to common .h file as #defines;
 uint8_t periph_rst = 22;	// peripheral reset asserted LOW to PCA9557, etc on board
 uint8_t ether_rst = 8;		// Wiznet module reset LOW
 
-/* ========== SETUP ========== */
+struct J_data
+	{
+	uint32_t	DC_data_in;			// data read from the DC board '165 shift register
+	uint16_t	AC_data_out;		// data sent to the AC board; send this before sending DC
+	uint16_t	DC_data_out;		// data sent to the DC board
+	} J2_data , J3_data, J4_data;
+
+	
+//---------------------------< S E T U P >--------------------------------------------------------------------
+
 void setup(void) 
-{
+	{
   	pinMode(periph_rst, OUTPUT);     
 	pinMode (ether_rst, OUTPUT);
 	
@@ -122,83 +140,109 @@ void setup(void)
 	digitalWrite(ether_rst, HIGH);
 
 	Serial.print("SALT2 J2 I2C Register Test Code at 0x");
-	Serial.println(coreJ2.BaseAddr, HEX);
-
-	/**
-	 *  Serial1 is a proprietary LCD and cap touch keypad
-	 */
-	// Serial1.begin(9600);			// UI Side 0 = LCD and keypad
-	// while((!Serial1) && (millis()<10000));		// wait until serial port is open or timeout
-	
-	// delay(2000);
-	//                0123456789ABCDEF 
-	// Serial1.println("dSALT J2 I2C Test");
+	Serial.println(coreJ2reg.BaseAddr, HEX);
 
 	/**
 	* Start, now inits invert and output bit enable, clears outputs
 	*/
-	coreJ2.begin();
-	coreJ3.begin();
-	coreJ4.begin();
+	coreJ2reg.begin();
+	coreJ3reg.begin();
+	coreJ4reg.begin();
 	coreFET.begin();
 	
 	// outmask, outdata, inputinvert
-	coreJ2.init(OUTMASK, (SCLK | RCLK595 | LED), 0);
-	coreJ3.init(OUTMASK, (SCLK | RCLK595 | LED), 0);
-	coreJ4.init(OUTMASK, (SCLK | RCLK595 | LED), 0);
+	coreJ2reg.init(OUTMASK, (SCLK | RCLK595 | LED), 0);
+	coreJ3reg.init(OUTMASK, (SCLK | RCLK595 | LED), 0);
+	coreJ4reg.init(OUTMASK, (SCLK | RCLK595 | LED), 0);
 	// FETs don't have clocks to downstream devices
 	// set all as outputs, all outputs off/low, no input inversion (none are inputs anyway)
 	coreFET.init(0xFF, 0x00, 0x00);
 
-	Serial.print(" Interval is ");
-	Serial.print(dtime/1000);
-	Serial.print(" sec, ");
-
-	Serial.println("Setup Complete!");
-	Serial.println(" "); 
-  
-}
-
-
-
-/* ========== LOOP ========== */
-void loop(void) 
-{
-	uint8_t read1=0;
-
-	Serial.print("@");
-	Serial.print(millis()/1000);
-	Serial.println(" ");
-	
-	for (uint8_t i = 0; i<4; i++) {
-		coreJ2.control_write(i);
-		Serial.print("At reg 0x");
-		Serial.print(i, HEX);
-		read1 = coreJ2.default_read();
-		Serial.print(" rd 0x");
-		Serial.println(read1, HEX);
+	coreJ2.AC_data_out = 0;				// clear DC and AC 595 registers
+	coreJ2.DC_data_out = 0;
+//	coreJ3.AC_data_out = 0;				// clear DC and AC 595 registers
+//	coreJ3.DC_data_out = 0;
+//	coreJ4.AC_data_out = 0;				// clear DC and AC 595 registers
+//	coreJ4.DC_data_out = 0;
+	coreJ2.update ();					// do it
+//	coreJ3.update (coreJ3reg);			// do it
+//	coreJ3.update (coreJ4reg);			// do it
+	coreJ2.AC_data_out = 0x8000;	// setup for walking-ones test
+//	coreJ3.AC_data_out = 0x8000;	// setup for walking-ones test
+//	coreJ3.AC_data_out = 0x8000;	// setup for walking-ones test
 	}
 
-	Serial.print("OUTMASK=0x");
-	Serial.println(OUTMASK, HEX);
-	
-	read1 = coreJ2.output_read();
-	Serial.print("Output read=0x");
-	Serial.println(read1, HEX);
-	
-	read1 = coreJ2.input_read();
-	Serial.print("Input=0x");
-	Serial.println(read1, HEX);
-	
-	coreJ2.pin_drive (LED, false);
-	// coreFET.pin_drive (LED, false);
-	coreFET.pin_drive ((0x80 | LED), false);
+	uint8_t fet_test = 0x80;
+
+
+//---------------------------< L O O P >----------------------------------------------------------------------
+
+void loop(void) 
+	{
+	if (0x80 & fet_test)
+		fet_test = 4;								// reset to bit 2, fluorescents
+	else
+		fet_test <<= 1;
+
+	coreFET.pin_drive ((fet_test | LED), HIGH);		// HIGH turn the LED off and the FET on
 	delay(1000);
 	
-	coreFET.pin_drive ((0x80 | LED), true);
-	coreJ2.pin_drive (LED, true);
+	coreFET.pin_drive ((fet_test | LED), LOW);		// LOW turn the LED on and the FET off
+//	coreJ2reg.pin_drive (LED, true);
 	// coreFET.pin_drive (LED, true);
+	
+	if (0x8000 & coreJ2.AC_data_out)			// when the '1' is in the MSB (bit 31)
+		{
+		coreJ2.AC_data_out = 0;				// clear so there is only one '1'
+		coreJ2.DC_data_out = 1;				// shift the '1' to lsb of DC data
+//		coreJ3.AC_data_out = 0;				// clear so there is only one '1'
+//		coreJ3.DC_data_out = 1;				// shift the '1' to lsb of DC data
+//		coreJ4.AC_data_out = 0;				// clear so there is only one '1'
+//		coreJ4.DC_data_out = 1;				// shift the '1' to lsb of DC data
+		}
+	else if (0x8000 & coreJ2.DC_data_out)		// when the '1' is in the DC board's MSB (bit 15)
+		{
+		coreJ2.AC_data_out = 1;				// shift the '1' to lsb of DC data
+		coreJ2.DC_data_out = 0;				// clear so there is only one '1'
+//		coreJ3.AC_data_out = 1;				// shift the '1' to lsb of DC data
+//		coreJ3.DC_data_out = 0;				// clear so there is only one '1'
+//		coreJ4.AC_data_out = 1;				// shift the '1' to lsb of DC data
+//		coreJ4.DC_data_out = 0;				// clear so there is only one '1'
+		}
+	else
+		{
+		coreJ2.AC_data_out <<= 1;			// shift both registers toward msb
+		coreJ2.DC_data_out <<= 1;
+//		coreJ3.AC_data_out <<= 1;			// shift both registers toward msb
+//		coreJ3.DC_data_out <<= 1;
+//		coreJ4.AC_data_out <<= 1;			// shift both registers toward msb
+//		coreJ4.DC_data_out <<= 1;
+		}
+
+
+	coreJ2.update ();						// do it
+//	coreJ3.update (coreJ3reg);				// do it
+//	coreJ4.update (coreJ4reg);				// do it
+
+/*	if (0x8000 & J2_data.AC_data_out)		// when the '1' is in the MSB (bit 31)
+		{
+		J2_data.AC_data_out = 0;
+		J2_data.DC_data_out = 1;
+		}
+	else if (0x8000 & J2_data.DC_data_out)	// when the '1' is in the DC board's MSB (bit 15)
+		{
+		J2_data.AC_data_out = 1;			// shift the '1' to lsb of DC data
+		J2_data.DC_data_out = 0;			// clear so there is only one '1'
+		}
+	else
+		{
+		J2_data.AC_data_out <<= 1;			// shift both registers toward msb
+		J2_data.DC_data_out <<= 1;
+		}
+	coreJ2.update ();
+*/
+	Serial.print("------INPUT------0x");
+	Serial.println(coreJ2.DC_data_in, HEX);
+
 	delay(1000);
-	
-	
-}
+	}


### PR DESCRIPTION
changes .cpp to stop the debug outputs.  The code for those outputs is probably broken; I made no effort to fix; just commented them out.

changes PCA9557_J2.ino to be a test bed for SALT_JX and SALT_FETs libraries.  The result bear little resemblance to the original.
